### PR TITLE
ConcurrentWeakInternSet JDKResource

### DIFF
--- a/src/java.base/share/classes/jdk/internal/crac/JDKResource.java
+++ b/src/java.base/share/classes/jdk/internal/crac/JDKResource.java
@@ -79,8 +79,9 @@ public interface JDKResource extends Resource {
          */
         REFERENCE_HANDLER,
         /**
-         * Priority of the
-         * jdk.internal.ref.CleanerImpl resources
+         * Priority of
+         * jdk.internal.ref.CleanerImpl resources,
+         * java.lang.invoke.MethodType.ConcurrentWeakInternSet resource
          */
         CLEANERS,
     };


### PR DESCRIPTION
Empty elements are removed from the ConcurrentWeakInternSet before the checkpoint.